### PR TITLE
Feature/provide data to events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Rider files
+.idea/

--- a/StreamElementsNET/StreamElementsNET/Models/Unknown/UnknownEventArgs.cs
+++ b/StreamElementsNET/StreamElementsNET/Models/Unknown/UnknownEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace StreamElementsNET.Models.Unknown
+{
+    public class UnknownEventArgs
+    {
+        public string Type { get; }
+        public JToken Data { get; }
+
+        public UnknownEventArgs(string type, JToken data)
+        {
+            Type = type;
+            Data = data;
+        }
+    }
+}

--- a/StreamElementsNET/StreamElementsNET/StreamElementsNET.csproj
+++ b/StreamElementsNET/StreamElementsNET/StreamElementsNET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>.netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is related to #4 where data is not being passed down to consumers so they cannot really handle non supported events themselves, this way they can through whatever mechanism they want.

In my scenario I want to be able to listen for redemptions and do things.