### PR TITLE
Feature/add redemption support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Rider files
+.idea/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ C# library for reading event data from StreamElements. Events include tips, subs
 
 ### Usage
 ```
-var streamElements = new StreamElementsNET.Client("<JWT-TOKEN>");
+var streamElements = new StreamElementsNET.Client();
 
 streamElements.OnConnected += StreamElements_OnConnected;
 streamElements.OnAuthenticated += StreamElements_OnAuthenticated;
@@ -73,7 +73,7 @@ streamElements.OnAuthenticationFailure += StreamElements_OnAuthenticationFailure
 streamElements.OnReceivedRawMessage += StreamElements_OnReceivedRawMessage;
 streamElements.OnSent += StreamElements_OnSent;
 
-streamElements.Connect();
+streamElements.Connect("<JWT-TOKEN>");
 ```
 
 ### Testing

--- a/StreamElementsNET/StreamElements.Test/StreamElements.Test/Program.cs
+++ b/StreamElementsNET/StreamElements.Test/StreamElements.Test/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using StreamElementsNET;
 
 namespace StreamElements.Test
 {
@@ -6,7 +7,8 @@ namespace StreamElements.Test
     {
         static void Main(string[] args)
         {
-            var streamElements = new StreamElementsNET.Client("<JWT-TOKEN>");
+            var token = "<JWT-TOKEN>";
+            var streamElements = new Client();
 
             streamElements.OnConnected += StreamElements_OnConnected;
             streamElements.OnAuthenticated += StreamElements_OnAuthenticated;
@@ -15,11 +17,13 @@ namespace StreamElements.Test
             streamElements.OnHost += StreamElements_OnHost;
             streamElements.OnTip += StreamElements_OnTip;
             streamElements.OnCheer += StreamElements_OnCheer;
+            streamElements.OnStoreRedemption += StreamElements_OnStoreRedemption;
             streamElements.OnAuthenticationFailure += StreamElements_OnAuthenticationFailure;
             streamElements.OnReceivedRawMessage += StreamElements_OnReceivedRawMessage;
             streamElements.OnSent += StreamElements_OnSent;
+            streamElements.OnUnknownSimpleUpdate += StreamElements_OnUnknown;
 
-            streamElements.Connect();
+            streamElements.Connect(token);
 
             while (true) ;
         }
@@ -72,6 +76,16 @@ namespace StreamElements.Test
         private static void StreamElements_OnConnected(object sender, EventArgs e)
         {
             Console.WriteLine($"Connected!");
+        }
+        
+        private static void StreamElements_OnStoreRedemption(object sender, StreamElementsNET.Models.Store.StoreRedemption e)
+        {
+            Console.WriteLine($"Store redemption: store item {e.StoreItemName} by {e.Username} with message {e.Message}");
+        }
+
+        private static void StreamElements_OnUnknown(object sender, StreamElementsNET.Models.Unknown.UnknownEventArgs e)
+        {
+            Console.WriteLine($"Unknown event args: {e.Type} - {e.Data}");
         }
     }
 }

--- a/StreamElementsNET/StreamElements.Test/StreamElements.Test/StreamElements.Test.csproj
+++ b/StreamElementsNET/StreamElements.Test/StreamElements.Test/StreamElements.Test.csproj
@@ -2,18 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="WebSocket4Net" Version="0.15.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="StreamElementsNET">
-      <HintPath>..\..\StreamElementsNET\bin\Debug\netcoreapp2.1\StreamElementsNET.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\StreamElementsNET\StreamElementsNET.csproj" />
   </ItemGroup>
-
+  
 </Project>

--- a/StreamElementsNET/StreamElementsNET.sln
+++ b/StreamElementsNET/StreamElementsNET.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28307.329
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StreamElementsNET", "StreamElementsNET\StreamElementsNET.csproj", "{42F5EB0D-3B65-4F6F-988B-AD2AE51C1E9A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StreamElements.Test", "StreamElements.Test\StreamElements.Test\StreamElements.Test.csproj", "{FB7D70A8-9358-4032-AE11-E6A924A30A62}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{42F5EB0D-3B65-4F6F-988B-AD2AE51C1E9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{42F5EB0D-3B65-4F6F-988B-AD2AE51C1E9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{42F5EB0D-3B65-4F6F-988B-AD2AE51C1E9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB7D70A8-9358-4032-AE11-E6A924A30A62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB7D70A8-9358-4032-AE11-E6A924A30A62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB7D70A8-9358-4032-AE11-E6A924A30A62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB7D70A8-9358-4032-AE11-E6A924A30A62}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/StreamElementsNET/StreamElementsNET/Client.cs
+++ b/StreamElementsNET/StreamElementsNET/Client.cs
@@ -187,7 +187,7 @@ namespace StreamElementsNET
             var provider = eventPayload["provider"]?.ToString() ?? string.Empty;
             if (provider != "twitch") { return;}
 
-            var eventType = eventPayload["type"]?.ToString();
+            var eventType = eventPayload["type"]?.ToString() ?? string.Empty;
             var eventData = eventPayload["data"];
             
             switch (eventType)

--- a/StreamElementsNET/StreamElementsNET/Client.cs
+++ b/StreamElementsNET/StreamElementsNET/Client.cs
@@ -11,7 +11,7 @@ namespace StreamElementsNET
         private readonly string StreamElementsUrl = "wss://realtime.streamelements.com/socket.io/?cluster=main&EIO=3&transport=websocket";
 
         private WebSocket client;
-        protected string jwt;
+        private string token;
         private Timer pingTimer;
 
         public event EventHandler OnConnected;
@@ -77,15 +77,16 @@ namespace StreamElementsNET
         public event EventHandler<Models.Subscriber.SubscriberNewLatest> OnSubscriberNewLatest;
         public event EventHandler<Models.Subscriber.SubscriberAlltimeGifter> OnSubscriberAlltimeGifter;
         public event EventHandler<Models.Subscriber.SubscriberGiftedLatest> OnSubscriberGiftedLatest;
+        
+        // store
+        public event EventHandler<Models.Store.StoreRedemption> OnStoreRedemption;
 
         // unknowns
         public event EventHandler<UnknownEventArgs> OnUnknownComplexObject;
         public event EventHandler<UnknownEventArgs> OnUnknownSimpleUpdate;
 
-        public Client(string jwtToken)
+        public Client()
         {
-            jwt = jwtToken;
-
             client = new WebSocket(StreamElementsUrl);
             client.Opened += Client_Opened;
             client.Error += Client_Error;
@@ -93,8 +94,9 @@ namespace StreamElementsNET
             client.MessageReceived += Client_MessageReceived;
         }
 
-        public void Connect()
+        public void Connect(string jwt)
         {
+            token = jwt;
             client.Open();
         }
 
@@ -116,7 +118,7 @@ namespace StreamElementsNET
 
         private void handleAuthentication()
         {
-            send($"42[\"authenticate\",{{\"method\":\"jwt\",\"token\":\"{jwt}\"}}]");
+            send($"42[\"authenticate\",{{\"method\":\"jwt\",\"token\":\"{token}\"}}]");
         }
 
         private void handlePingInitialization(Models.Internal.SessionMetadata md)
@@ -176,33 +178,37 @@ namespace StreamElementsNET
 
         private void handleComplexObject(JArray decoded)
         {
-            // only handle "event" types
-            if (decoded[0].ToString() != "event")
-                return;
-            // only handle follows from twitch
-            if (decoded[1]["provider"].ToString() != "twitch")
-                return;
+            var objectType = decoded[0]?.ToString() ?? string.Empty;
+            if (objectType != "event") { return; }
 
-            var type = decoded[1]["type"].ToString();
-            switch (type)
+            var eventPayload = decoded[1];
+            if(eventPayload == null) { return; }
+            
+            var provider = eventPayload["provider"]?.ToString() ?? string.Empty;
+            if (provider != "twitch") { return;}
+
+            var eventType = eventPayload["type"]?.ToString();
+            var eventData = eventPayload["data"];
+            
+            switch (eventType)
             {
                 case "follow":
-                    OnFollower?.Invoke(client, Parsing.Follower.handleFollower(decoded[1]["data"]));
+                    OnFollower?.Invoke(client, Parsing.Follower.handleFollower(eventData));
                     return;
                 case "cheer":
-                    OnCheer?.Invoke(client, Parsing.Cheer.handleCheer(decoded[1]["data"]));
+                    OnCheer?.Invoke(client, Parsing.Cheer.handleCheer(eventData));
                     return;
                 case "host":
-                    OnHost?.Invoke(client, Parsing.Host.handleHost(decoded[1]["data"]));
+                    OnHost?.Invoke(client, Parsing.Host.handleHost(eventData));
                     return;
                 case "tip":
-                    OnTip?.Invoke(client, Parsing.Tip.handleTip(decoded[1]["data"]));
+                    OnTip?.Invoke(client, Parsing.Tip.handleTip(eventData));
                     return;
                 case "subscriber":
-                    OnSubscriber?.Invoke(client, Parsing.Subscriber.handleSubscriber(decoded[1]["data"]));
+                    OnSubscriber?.Invoke(client, Parsing.Subscriber.handleSubscriber(eventData));
                     return;
                 default:
-                    OnUnknownComplexObject?.Invoke(client, new UnknownEventArgs(type, decoded[1]["data"]));
+                    OnUnknownComplexObject?.Invoke(client, new UnknownEventArgs(eventType, eventData));
                     return;
             }
         }
@@ -212,9 +218,12 @@ namespace StreamElementsNET
             // only handle "event:update" types
             if (decoded[0].ToString() != "event:update")
                 return;
+
+            var eventPayload = decoded[1];
+            if(eventPayload == null) { return; }
             
-            var data = decoded[1]["data"];
-            var type = decoded[1]["name"].ToString();
+            var data = eventPayload["data"];
+            var type = eventPayload["name"]?.ToString() ?? string.Empty;
             
             switch (type)
             {
@@ -334,6 +343,9 @@ namespace StreamElementsNET
                     return;
                 case "subscriber-gifted-latest":
                     OnSubscriberGiftedLatest?.Invoke(client, Parsing.Subscriber.handleSubscriberGiftedLatest(data));
+                    return;
+                case "redemption-latest":
+                    OnStoreRedemption?.Invoke(client, Parsing.StoreRedemption.handleStoreRedemption(data));
                     return;
                 default:
                     OnUnknownSimpleUpdate?.Invoke(client, new UnknownEventArgs(type, decoded[1]["data"]));

--- a/StreamElementsNET/StreamElementsNET/Models/Store/StoreRedemption.cs
+++ b/StreamElementsNET/StreamElementsNET/Models/Store/StoreRedemption.cs
@@ -1,0 +1,20 @@
+﻿namespace StreamElementsNET.Models.Store
+{
+    public class StoreRedemption
+    {
+        public string ItemId { get; }
+        public string Username { get; }
+        public string Type { get; }
+        public string StoreItemName { get; }
+        public string Message { get; }
+
+        public StoreRedemption(string itemId, string username, string type, string storeItemName, string message)
+        {
+            ItemId = itemId;
+            Username = username;
+            Type = type;
+            StoreItemName = storeItemName;
+            Message = message;
+        }
+    }
+}

--- a/StreamElementsNET/StreamElementsNET/Models/Unknown/UnknownEventArgs.cs
+++ b/StreamElementsNET/StreamElementsNET/Models/Unknown/UnknownEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace StreamElementsNET.Models.Unknown
+{
+    public class UnknownEventArgs
+    {
+        public string Type { get; }
+        public JToken Data { get; }
+
+        public UnknownEventArgs(string type, JToken data)
+        {
+            Type = type;
+            Data = data;
+        }
+    }
+}

--- a/StreamElementsNET/StreamElementsNET/Parsing/StoreRedemption.cs
+++ b/StreamElementsNET/StreamElementsNET/Parsing/StoreRedemption.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace StreamElementsNET.Parsing
+{
+    public static class StoreRedemption
+    {
+        public static Models.Store.StoreRedemption handleStoreRedemption(JToken json)
+        {
+            return new Models.Store.StoreRedemption(json["itemId"].ToString(), json["name"].ToString(), 
+                json["type"].ToString(), json["item"].ToString(), json["message"]?.ToString() ?? string.Empty);
+        }
+    }
+}

--- a/StreamElementsNET/StreamElementsNET/StreamElementsNET.csproj
+++ b/StreamElementsNET/StreamElementsNET/StreamElementsNET.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="WebSocket4Net" Version="0.15.2" />
   </ItemGroup>
 

--- a/StreamElementsNET/StreamElementsNET/StreamElementsNET.csproj
+++ b/StreamElementsNET/StreamElementsNET/StreamElementsNET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>.netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This contains the main change for store redemption support, so when someone redeems something from the store it will allow you to hook into that event.

There was also an issue where for some reason the complex ones kept blowing up when testing the redemptions as the provider field was missing, so this has been fixed so if it doesnt exist just short circuit. Also I have moved the jwt to be on the connection not the creation of the instance as it is only needed at point of connecting.

This builds on top of #5 so I would approve that one first before this one gets looked at, but you could potentially bin that one and just accept this one if you are happy with changes.